### PR TITLE
Remove all other deprecated fixed width int libc variables.

### DIFF
--- a/optee-teec/optee-teec-sys/src/tee_client_api.rs
+++ b/optee-teec/optee-teec-sys/src/tee_client_api.rs
@@ -68,9 +68,9 @@ pub struct TEEC_Context {
 #[repr(C)]
 pub struct TEEC_UUID {
     pub timeLow: u32,
-    pub timeMid: uint16_t,
-    pub timeHiAndVersion: uint16_t,
-    pub clockSeqAndNode: [uint8_t; 8],
+    pub timeMid: u16,
+    pub timeHiAndVersion: u16,
+    pub clockSeqAndNode: [u8; 8],
 }
 
 #[repr(C)]

--- a/optee-utee/optee-utee-sys/src/tee_api.rs
+++ b/optee-utee/optee-utee-sys/src/tee_api.rs
@@ -94,7 +94,7 @@ extern "C" {
         buffer1: *const c_void,
         buffer2: *const c_void,
         size: u32,
-    ) -> int32_t;
+    ) -> i32;
     pub fn TEE_MemFill(buff: *mut c_void, x: u32, size: u32) -> *mut c_void;
 
     // Data and Key Storage API  - Generic Object Functions
@@ -219,7 +219,7 @@ extern "C" {
     pub fn TEE_TruncateObjectData(object: TEE_ObjectHandle, size: u32) -> TEE_Result;
     pub fn TEE_SeekObjectData(
         object: TEE_ObjectHandle,
-        offset: int32_t,
+        offset: i32,
         whence: TEE_Whence,
     ) -> TEE_Result;
 
@@ -438,22 +438,22 @@ extern "C" {
 
     pub fn TEE_BigIntConvertFromOctetString(
         dest: *mut TEE_BigInt,
-        buffer: *const uint8_t,
+        buffer: *const u8,
         bufferLen: u32,
-        sign: int32_t,
+        sign: i32,
     ) -> TEE_Result;
     pub fn TEE_BigIntConvertToOctetString(
-        buffer: *mut uint8_t,
+        buffer: *mut u8,
         bufferLen: *mut u32,
         bigInt: *const TEE_BigInt,
     ) -> TEE_Result;
-    pub fn TEE_BigIntConvertFromS32(dest: *mut TEE_BigInt, shortVal: int32_t) -> c_void;
-    pub fn TEE_BigIntConvertToS32(dest: *mut int32_t, src: *const TEE_BigInt) -> TEE_Result;
+    pub fn TEE_BigIntConvertFromS32(dest: *mut TEE_BigInt, shortVal: i32) -> c_void;
+    pub fn TEE_BigIntConvertToS32(dest: *mut i32, src: *const TEE_BigInt) -> TEE_Result;
 
     // TEE Arithmetical API - Logical operations
 
-    pub fn TEE_BigIntCmp(op1: *const TEE_BigInt, op2: *const TEE_BigInt) -> int32_t;
-    pub fn TEE_BigIntCmpS32(op: *const TEE_BigInt, shortVal: int32_t) -> int32_t;
+    pub fn TEE_BigIntCmp(op1: *const TEE_BigInt, op2: *const TEE_BigInt) -> i32;
+    pub fn TEE_BigIntCmpS32(op: *const TEE_BigInt, shortVal: i32) -> i32;
     pub fn TEE_BigIntShiftRight(
         dest: *mut TEE_BigInt,
         op: *const TEE_BigInt,
@@ -531,7 +531,7 @@ extern "C" {
         op1: *const TEE_BigInt,
         op2: *const TEE_BigInt,
     ) -> c_void;
-    pub fn TEE_BigIntIsProbablePrime(op: *const TEE_BigInt, confidenceLevel: u32) -> int32_t;
+    pub fn TEE_BigIntIsProbablePrime(op: *const TEE_BigInt, confidenceLevel: u32) -> i32;
 
     // TEE Arithmetical API - Fast modular multiplication operations
 

--- a/optee-utee/optee-utee-sys/src/tee_api_types.rs
+++ b/optee-utee/optee-utee-sys/src/tee_api_types.rs
@@ -8,9 +8,9 @@ pub type TEE_Result = u32;
 #[derive(Copy, Clone)]
 pub struct TEE_UUID {
     pub timeLow: u32,
-    pub timeMid: uint16_t,
-    pub timeHiAndVersion: uint16_t,
-    pub clockSeqAndNode: [uint8_t; 8],
+    pub timeMid: u16,
+    pub timeHiAndVersion: u16,
+    pub clockSeqAndNode: [u8; 8],
 }
 
 #[repr(C)]
@@ -197,7 +197,7 @@ pub struct TEE_SEReaderProperties {
 
 #[repr(C)]
 pub struct TEE_SEAID {
-    pub buffer: *mut uint8_t,
+    pub buffer: *mut u8,
     pub bufferLen: size_t,
 }
 

--- a/optee-utee/optee-utee-sys/src/utee_syscalls.rs
+++ b/optee-utee/optee-utee-sys/src/utee_syscalls.rs
@@ -205,7 +205,7 @@ extern "C" {
     ) -> TEE_Result;
     pub fn utee_storage_obj_write(obj: c_ulong, data: *const c_void, len: size_t) -> TEE_Result;
     pub fn utee_storage_obj_trunc(obj: c_ulong, len: size_t) -> TEE_Result;
-    pub fn utee_storage_obj_seek(obj: c_ulong, offset: int32_t, whence: c_ulong) -> TEE_Result;
+    pub fn utee_storage_obj_seek(obj: c_ulong, offset: i32, whence: c_ulong) -> TEE_Result;
     pub fn utee_cache_operation(va: *mut c_void, l: size_t, op: c_ulong) -> TEE_Result;
 // unimplemented syscall
 // pub fn utee_gprof_send(buf: *mut c_void, size: size_t, id: *mut u32) -> TEE_Result;

--- a/optee-utee/systest/src/main.rs
+++ b/optee-utee/systest/src/main.rs
@@ -1,6 +1,5 @@
 #![allow(bad_style)]
 
-use libc::*;
 use optee_utee_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/all.rs"));


### PR DESCRIPTION
Removed all 'libc::\*int\*_t' in code.